### PR TITLE
Update sfh.h

### DIFF
--- a/sfh.h
+++ b/sfh.h
@@ -48,7 +48,7 @@ struct config{
 	char unix_sock_path[128];
 };
 
-struct config *config;
+static struct config *config;
 
 enum request_type{
 	R_INVALID,


### PR DESCRIPTION
Making global variable "*config" static to avoid "Multiple definition" linker error.